### PR TITLE
Allow toggling checker from badge

### DIFF
--- a/Textoo_v1.4.0 (1)/style.css
+++ b/Textoo_v1.4.0 (1)/style.css
@@ -4,7 +4,8 @@
 .textoo-overlay .textoo-highlight.style{ text-decoration-color:#1e88e5 }
 .textoo-overlay .textoo-highlight.typography{ text-decoration-color:#6a1b9a }
 .textoo-marker{pointer-events:auto}
-.textoo-badge{position:absolute;right:-10px;top:-10px;background:#e53935;color:#fff;font:12px/16px system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;width:18px;height:18px;border-radius:9px;display:none;align-items:center;justify-content:center;z-index:2147483647;box-shadow:0 1px 2px rgba(0,0,0,.25)}
+.textoo-badge{position:absolute;right:-10px;top:-10px;background:#e53935;color:#fff;font:12px/16px system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;width:18px;height:18px;border-radius:9px;display:none;align-items:center;justify-content:center;z-index:2147483647;box-shadow:0 1px 2px rgba(0,0,0,.25);cursor:pointer;user-select:none}
+.textoo-badge-disabled{background:#9e9e9e;box-shadow:0 1px 2px rgba(0,0,0,.2)}
 .textoo-popover{position:fixed;max-width:360px;background:#fff;color:#111;border:1px solid rgba(0,0,0,.15);border-radius:10px;box-shadow:0 10px 30px rgba(0,0,0,.18);padding:10px 8px;z-index:2147483647;font:13px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
 .textoo-popover-header{font-weight:600;margin-bottom:6px}
 .textoo-suggest{display:inline-block;margin:4px 4px 0 0;padding:6px 8px;border-radius:6px;background:#f2f6ff;color:#0b57d0;border:1px solid #c9d7ff;cursor:pointer;user-select:none}


### PR DESCRIPTION
## Summary
- allow the per-field badge to toggle the checker on or off without removing the counter
- pause scans while disabled and update the badge styling/labels to reflect the inactive state

## Testing
- not run (extension)


------
https://chatgpt.com/codex/tasks/task_b_68d072dfe7508331bc592ece2f091dd2